### PR TITLE
Add Next.js skeleton with Tailwind, Material UI and login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# dogShelter
+# Dog Shelter
+
+This is a demo Next.js 15 project using Yarn, Tailwind CSS and Material UI. It provides a responsive design, a simple login page, and basic SEO setup.
+
+## Development
+
+1. Install dependencies:
+
+```bash
+yarn install
+```
+
+2. Start the development server:
+
+```bash
+yarn dev
+```
+
+## Features
+
+- **Responsive design** using Tailwind CSS and Material UI.
+- **Login page** at `/login`.
+- **SEO** handled via `next-seo`.
+
+Run `yarn build` to create a production build.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,25 @@
+import './globals.css';
+import { DefaultSeo } from 'next-seo';
+import SEO from '../next-seo.config';
+import { CssBaseline } from '@mui/material';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata = {
+  title: 'Dog Shelter',
+  description: 'Adopt adorable dogs from our shelter',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head />
+      <body className={inter.className}>
+        <DefaultSeo {...SEO} />
+        <CssBaseline />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useState } from 'react';
+import { Button, TextField, Container, Typography } from '@mui/material';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert(`Login with ${email}`);
+  };
+
+  return (
+    <Container maxWidth="sm" className="mt-10">
+      <Typography variant="h4" gutterBottom>Login</Typography>
+      <form onSubmit={handleSubmit} className="flex flex-col space-y-4">
+        <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} fullWidth />
+        <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} fullWidth />
+        <Button variant="contained" type="submit">Login</Button>
+      </form>
+    </Container>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+import ResponsiveGrid from '../components/ResponsiveGrid';
+
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Welcome to Dog Shelter</h1>
+      <ResponsiveGrid />
+    </main>
+  );
+}

--- a/components/ResponsiveGrid.tsx
+++ b/components/ResponsiveGrid.tsx
@@ -1,0 +1,15 @@
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+
+export default function ResponsiveGrid() {
+  const dogs = ['Fido', 'Spot', 'Luna', 'Charlie'];
+  return (
+    <Grid container spacing={2}>
+      {dogs.map((dog) => (
+        <Grid item xs={12} sm={6} md={3} key={dog}>
+          <Paper className="p-4 text-center">{dog}</Paper>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types='next' />\n/// <reference types='next/types/global' />\n

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next-seo').DefaultSeoProps} */
+const SEO = {
+  title: 'Dog Shelter',
+  description: 'Adopt adorable dogs from our shelter.',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://example.com',
+    site_name: 'Dog Shelter',
+  },
+};
+
+module.exports = SEO;

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "dogShelter",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-seo": "^7.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "@mui/material": "^5.15.0",
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1,0 +1,1 @@
+# Run 'yarn install' to generate lockfile


### PR DESCRIPTION
## Summary
- initialize Next.js 15 project skeleton
- add Tailwind CSS and Material UI setup
- include basic SEO config with `next-seo`
- implement responsive grid component
- create login page
- update README with Yarn usage

## Testing
- `git status --short`
